### PR TITLE
Implement basic types

### DIFF
--- a/vm/src/deserializer.cpp
+++ b/vm/src/deserializer.cpp
@@ -1,0 +1,42 @@
+#include "deserializer.h"
+#include <cassert>
+#include <stdexcept>
+
+namespace Borges {
+
+Deserializer::Deserializer(std::size_t n, const double* p)
+    : buffer_size_(n), buffer_data_(p), buffer_index_(0)
+{
+    assert(buffer_data_);
+}
+
+void
+Deserializer::deserialize(double* p)
+{
+    if (buffer_index_ == buffer_size_) {
+        throw std::runtime_error("buffer underflow");
+    }
+    double x = buffer_data_[buffer_index_];
+    ++buffer_index_;
+    *p = x;
+}
+
+void
+deserialize(Deserializer& d, bool* p)
+{
+    *p = deserialize<double>(d);
+}
+
+void
+deserialize(Deserializer& d, double* p)
+{
+    d.deserialize(p);
+}
+
+void
+deserialize(Deserializer& d, std::size_t* p)
+{
+    *p = deserialize<double>(d);
+}
+
+} // namespace Borges

--- a/vm/src/deserializer.h
+++ b/vm/src/deserializer.h
@@ -1,0 +1,115 @@
+#ifndef BORGES_DESERIALIZER_H
+#define BORGES_DESERIALIZER_H
+
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Borges {
+
+// Encapsulates the state necessary to deserialize C++ values from a buffer.
+class Deserializer {
+public:
+    // Creates a deserializer that reads from a buffer with size `n` and data
+    // pointed to by the pointer `p`.
+    //
+    // Note that the deserializer does not own `p`.
+    Deserializer(std::size_t n, const double* p);
+    void deserialize(double* p);
+    template <typename T>
+    void deserialize(std::shared_ptr<T>* p);
+
+private:
+    std::size_t buffer_size_;
+    const double* buffer_data_;
+    std::size_t buffer_index_;
+    std::unordered_map<std::size_t, std::shared_ptr<void>> index_to_ptr_map_;
+};
+
+void deserialize(Deserializer& d, bool* p);
+void deserialize(Deserializer& d, double* p);
+void deserialize(Deserializer& d, std::size_t* p);
+
+// This is the main deserialization function.
+//
+// Since C++ does not allow partial specialization of template functions, this
+// function should not be specialized directly. If you want to make your type
+// deserializable, you should add an overload of the helper function used by
+// this function to construct a value in uninitialized storage instead.
+template <typename T>
+T
+deserialize(Deserializer& d)
+{
+    // To deserialize a value of type `T`, we need to create a temporary value
+    // to which the value to be deserialized can be assigned. Since `T` might
+    // not have a default constructor, we don't create this temporary value
+    // directly. Instead, we create a buffer of uninitialized storage `b` that
+    // is properly aligned for values of type `T`, and then call a helper
+    // function that directly constructs a value of type `T` in `b`.
+    alignas(T) char b[sizeof(T)];
+    T* p = reinterpret_cast<T*>(b);
+    deserialize(d, p);
+    // Make sure that the value stored in `b` is properly destructed, by first
+    // moving it to the temporary value `v`, and then explicitly calling the
+    // destructor on the pointer `p` to `b`. The explicit destructor call is
+    // necessary because `T` might not have a move constructor, in which case
+    // the value will be copied instead.
+    T v(std::move(*p));
+    p->~T();
+    return std::move(v);
+}
+
+template <typename T>
+void
+Deserializer::deserialize(std::shared_ptr<T>* p)
+{
+    // Deserialize the index `i` associated with the pointer.
+    std::size_t i = Borges::deserialize<std::size_t>(*this);
+    // If there is a pointer associated with `i`, we have encountered the
+    // pointer before. In this case, we can reconstruct the pointer from `i`
+    // alone, by copy constructing it with the pointer associated with `i`.
+    auto it = index_to_ptr_map_.find(i);
+    if (it != index_to_ptr_map_.end()) {
+        new (p) std::shared_ptr<T>(it->second);
+        return;
+    }
+    // Otherwise, this is the first time we have encountered the pointer.
+    // Deserialize the value being pointed to by the pointer, use it to
+    // reconstruct the pointer, and associate the pointer with `i`, so that
+    // subsequent occurences of the pointer can be reconstructed from `i` alone.
+    std::shared_ptr<T> ptr(std::make_shared<T>(deserialize<T>(*this)));
+    new (p) std::shared_ptr<T>(std::move(ptr));
+    index_to_ptr_map_.insert(std::make_pair(i, std::shared_ptr<void>(ptr)));
+}
+
+template<typename T>
+void
+deserialize(Deserializer& d, std::unique_ptr<T>* p)
+{
+    new (p) std::unique_ptr<T>(new T(deserialize<T>(d)));
+}
+
+template <typename T>
+void
+deserialize(Deserializer& deserializer, std::shared_ptr<T>* p)
+{
+    deserializer.deserialize(p);
+}
+
+template <typename T>
+void
+deserialize(Deserializer& d, std::vector<T>* p)
+{
+    std::size_t n = deserialize<std::size_t>(d);
+    std::vector<T> xs;
+    xs.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        xs.push_back(deserialize<T>(d));
+    }
+    new (p) std::vector<T>(std::move(xs));
+}
+
+} // namespace Borges
+
+#endif // BORGES_DESERIALIZER_H

--- a/vm/src/matrix_3.cpp
+++ b/vm/src/matrix_3.cpp
@@ -1,0 +1,91 @@
+#include "matrix_3.h"
+#include "deserializer.h"
+#include "serializer.h"
+#include <cassert>
+
+namespace Borges {
+
+double
+Matrix_3::Const_row::operator[](std::size_t j) const
+{
+    assert(j < 3);
+    return mi_[j];
+}
+
+Matrix_3::Const_row::Const_row(const double* mi) : mi_(mi)
+{
+}
+
+Matrix_3::Matrix_3(std::initializer_list<std::initializer_list<double>> m)
+{
+    assert(m.size() == 3);
+    for (std::size_t i = 0; i < 3; ++i) {
+        std::initializer_list<double> row = m.begin()[i];
+        assert(row.size() == 3);
+        for (std::size_t j = 0; j < 3; ++j) {
+            m_[i][j] = row.begin()[j];
+        }
+    }
+}
+
+Matrix_3::Matrix_3(const double (*m)[3])
+{
+    for (std::size_t i = 0; i < 3; ++i) {
+        const double* row = m[i];
+        for (std::size_t j = 0; j < 3; ++j) {
+            m_[i][j] = row[j];
+        }
+    }
+}
+
+auto
+Matrix_3::operator[](std::size_t i) const -> Const_row
+{
+    assert(i < 3);
+    return Const_row(m_[i]);
+}
+
+void
+serialize(Serializer& s, const Matrix_3& m)
+{
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            serialize(s, m[i][j]);
+        }
+    }
+}
+
+void
+deserialize(Deserializer& d, Matrix_3* p)
+{
+    double m[3][3];
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            m[i][j] = deserialize<double>(d);
+        }
+    }
+    new (p) Matrix_3(m);
+}
+
+Matrix_3
+identity_matrix_3()
+{
+    return Matrix_3({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+}
+
+Matrix_3
+operator*(const Matrix_3& m1, const Matrix_3& m2)
+{
+    double m[3][3];
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+          m[i][j] = 0.0;
+          for (std::size_t k = 0; k < 3; ++k) {
+              m[i][j] += m1[i][k] * m2[k][j];
+          }
+        }
+    }
+    return Matrix_3(m);
+}
+
+} // namespace Borges

--- a/vm/src/matrix_3.h
+++ b/vm/src/matrix_3.h
@@ -1,0 +1,51 @@
+#ifndef BORGES_MATRIX_3_H
+#define BORGES_MATRIX_3_H
+
+#include "type.h"
+#include <initializer_list>
+
+namespace Borges {
+
+class Serializer;
+class Deserializer;
+
+class Matrix_3 {
+public:
+    class Const_row {
+    public:
+        double operator[](std::size_t j) const;
+
+    private:
+        friend class Matrix_3;
+
+        Const_row(const double* mi);
+
+        const double* mi_;
+    };
+
+    explicit Matrix_3(std::initializer_list<std::initializer_list<double>> m);
+    explicit Matrix_3(const double (*m)[3]);
+    Const_row operator[](std::size_t i) const;
+
+private:
+    double m_[3][3];
+};
+
+template <>
+struct Type_of<Matrix_3>
+    : std::integral_constant<Type, Type::matrix_3> {
+};
+
+template <>
+struct Type_of<std::vector<Matrix_3>>
+    : std::integral_constant<Type, Type::matrix_3_array> {
+};
+
+void serialize(Serializer& s, const Matrix_3& m);
+void deserialize(Deserializer& d, Matrix_3* p);
+Matrix_3 identity_matrix_3();
+Matrix_3 operator*(const Matrix_3& m1, const Matrix_3& m2);
+
+} // namespace Borges
+
+#endif // BORGES_MATRIX_3_H

--- a/vm/src/matrix_4.cpp
+++ b/vm/src/matrix_4.cpp
@@ -1,0 +1,91 @@
+#include "matrix_4.h"
+#include "deserializer.h"
+#include "serializer.h"
+#include <cassert>
+
+namespace Borges {
+
+double
+Matrix_4::Const_row::operator[](std::size_t j) const
+{
+    assert(j < 4);
+    return mi_[j];
+}
+
+Matrix_4::Const_row::Const_row(const double* mi) : mi_(mi)
+{
+}
+
+Matrix_4::Matrix_4(std::initializer_list<std::initializer_list<double>> m)
+{
+    assert(m.size() == 4);
+    for (std::size_t i = 0; i < 4; ++i) {
+        std::initializer_list<double> row = m.begin()[i];
+        assert(row.size() == 4);
+        for (std::size_t j = 0; j < 4; ++j) {
+            m_[i][j] = row.begin()[j];
+        }
+    }
+}
+
+Matrix_4::Matrix_4(const double (*m)[4])
+{
+    for (std::size_t i = 0; i < 4; ++i) {
+        const double* row = m[i];
+        for (std::size_t j = 0; j < 4; ++j) {
+            m_[i][j] = row[j];
+        }
+    }
+}
+
+auto
+Matrix_4::operator[](std::size_t i) const -> Const_row
+{
+    assert(i < 4);
+    return Const_row(m_[i]);
+}
+
+void
+serialize(Serializer& s, const Matrix_4& m)
+{
+    for (std::size_t i = 0; i < 4; ++i) {
+        for (std::size_t j = 0; j < 4; ++j) {
+            serialize(s, m[i][j]);
+        }
+    }
+}
+
+void
+deserialize(Deserializer& d, Matrix_4* p)
+{
+    double m[4][4];
+    for (std::size_t i = 0; i < 4; ++i) {
+        for (std::size_t j = 0; j < 4; ++j) {
+            m[i][j] = deserialize<double>(d);
+        }
+    }
+    new (p) Matrix_4(m);
+}
+
+Matrix_4
+identity_matrix_4()
+{
+    return Matrix_4({{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}});
+}
+
+Matrix_4
+operator*(const Matrix_4& m1, const Matrix_4& m2)
+{
+    double m[4][4];
+    for (std::size_t i = 0; i < 4; ++i) {
+        for (std::size_t j = 0; j < 4; ++j) {
+          m[i][j] = 0.0;
+          for (std::size_t k = 0; k < 4; ++k) {
+              m[i][j] += m1[i][k] * m2[k][j];
+          }
+        }
+    }
+    return Matrix_4(m);
+}
+
+} // namespace Borges

--- a/vm/src/matrix_4.h
+++ b/vm/src/matrix_4.h
@@ -1,0 +1,51 @@
+#ifndef BORGES_MATRIX_4_H
+#define BORGES_MATRIX_4_H
+
+#include "type.h"
+#include <initializer_list>
+
+namespace Borges {
+
+class Serializer;
+class Deserializer;
+
+class Matrix_4 {
+public:
+    class Const_row {
+    public:
+        double operator[](std::size_t j) const;
+
+    private:
+        friend class Matrix_4;
+
+        Const_row(const double* mi);
+
+        const double* mi_;
+    };
+
+    explicit Matrix_4(std::initializer_list<std::initializer_list<double>> m);
+    explicit Matrix_4(const double (*m)[4]);
+    Const_row operator[](std::size_t i) const;
+
+private:
+    double m_[4][4];
+};
+
+template <>
+struct Type_of<Matrix_4>
+    : std::integral_constant<Type, Type::matrix_4> {
+};
+
+template <>
+struct Type_of<std::vector<Matrix_4>>
+    : std::integral_constant<Type, Type::matrix_4_array> {
+};
+
+void serialize(Serializer& s, const Matrix_4& m);
+void deserialize(Deserializer& d, Matrix_4* p);
+Matrix_4 identity_matrix_4();
+Matrix_4 operator*(const Matrix_4& m1, const Matrix_4& m2);
+
+} // namespace Borges
+
+#endif // BORGES_MATRIX_4_H

--- a/vm/src/serializer.cpp
+++ b/vm/src/serializer.cpp
@@ -1,0 +1,33 @@
+#include "serializer.h"
+
+namespace Borges {
+
+Serializer::Serializer(std::vector<double>& b) : buffer_(b)
+{
+}
+
+void
+Serializer::serialize(double x)
+{
+    buffer_.push_back(x);
+}
+
+void
+serialize(Serializer& s, bool p)
+{
+    serialize(s, static_cast<double>(p));
+}
+
+void
+serialize(Serializer& s, double x)
+{
+    s.serialize(x);
+}
+
+void
+serialize(Serializer& s, std::size_t n)
+{
+    serialize(s, static_cast<double>(n));
+}
+
+} // namespace Borges

--- a/vm/src/serializer.h
+++ b/vm/src/serializer.h
@@ -1,0 +1,80 @@
+#ifndef BORGES_SERIALIZER_H
+#define BORGES_SERIALIZER_H
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace Borges {
+
+// Encapsulates the state necessary to serialize C++ values to a buffer.
+class Serializer {
+public:
+    // Creates a serializer that writes to the buffer `b`.
+    //
+    // Note that the serializer does not own `b`.
+    Serializer(std::vector<double>& b);
+    void serialize(double x);
+    template <typename T>
+    void serialize(const std::shared_ptr<T>& p);
+
+private:
+    std::vector<double>& buffer_;
+    std::unordered_map<std::shared_ptr<void>, std::size_t> ptr_to_index_map_;
+};
+
+template <typename T>
+void
+Serializer::serialize(const std::shared_ptr<T>& p)
+{
+    // If there is an index associated with `p`, we have encountered `p`
+    // before, so only serialize the index. During deserialization, we will
+    // associate `p` with the index when we first encounter it, so subsequent
+    // occurences of `p` can be reconstructed from the index alone.
+    auto it = ptr_to_index_map_.find(p);
+    if (it == ptr_to_index_map_.end()) {
+      serialize(*this, it->second);
+      return;
+    }
+    // Otherwise, this is the first time we have encountered `p`. Create a
+    // unique index `i`, serialize both `i` and the value pointed to by `p`,
+    // so that `p` can be associated with `i` when we first encounter it during
+    // deserialization, and associate `i` with `p`.
+    std::size_t i = ptr_to_index_map_.size();
+    serialize(i);
+    serialize(*p);
+    ptr_to_index_map_.insert(std::make_pair(std::shared_ptr<void>(p), i));
+}
+
+void serialize(Serializer& s, bool p);
+void serialize(Serializer& s, double x);
+void serialize(Serializer& s, std::size_t n);
+
+template <typename T>
+void
+serialize(Serializer& s, const std::unique_ptr<T> p)
+{
+    serialize(s, *p);
+}
+
+template <typename T>
+void
+serialize(Serializer& s, const std::shared_ptr<T> p)
+{
+    s.serialize(p);
+}
+
+template <typename T>
+void
+serialize(Serializer& s, const std::vector<T>& xs)
+{
+    std::size_t n = xs.size();
+    serialize(s, n);
+    for (std::size_t i = 0; i < n; ++i) {
+        serialize(s, xs[i]);
+    }
+}
+
+} // namespace Borges
+
+#endif // BORGES_SERIALIZER_H

--- a/vm/src/type.cpp
+++ b/vm/src/type.cpp
@@ -1,0 +1,19 @@
+#include "type.h"
+#include "deserializer.h"
+#include "serializer.h"
+
+namespace Borges {
+
+void
+serialize(Serializer& s, Type t)
+{
+    serialize(s, static_cast<std::size_t>(t));
+}
+
+void
+deserialize(Deserializer& d, Type* p)
+{
+    *p = static_cast<Type>(deserialize<std::size_t>(d));
+}
+
+} // namespace Borges

--- a/vm/src/type.h
+++ b/vm/src/type.h
@@ -1,0 +1,56 @@
+#ifndef BORGES_TYPE_H
+#define BORGES_TYPE_H
+
+#include <cstddef>
+#include <type_traits>
+#include <vector>
+
+namespace Borges {
+
+class Serializer;
+class Deserializer;
+
+// Identifies the run-time type of a value.
+enum class Type : std::size_t {
+    boolean,
+    number,
+    vector_2,
+    vector_3,
+    matrix_3,
+    matrix_4,
+    boolean_array,
+    number_array,
+    vector_2_array,
+    vector_3_array,
+    matrix_3_array,
+    matrix_4_array
+};
+
+// Obtains the run-time type of a value of type `T`.
+template <typename T>
+struct Type_of;
+
+template <>
+struct Type_of<bool> : std::integral_constant<Type, Type::boolean> {
+};
+
+template <>
+struct Type_of<double> : std::integral_constant<Type, Type::number> {
+};
+
+template <>
+struct Type_of<std::vector<bool>>
+    : std::integral_constant<Type, Type::boolean_array> {
+};
+
+template <>
+struct Type_of<std::vector<double>>
+    : std::integral_constant<Type, Type::number_array> {
+};
+
+void serialize(Serializer& s, Type t);
+void deserialize(Deserializer& d, Type* p);
+
+} // namespace Borges
+
+#endif // BORGES_TYPE_H

--- a/vm/src/vector_2.cpp
+++ b/vm/src/vector_2.cpp
@@ -1,0 +1,63 @@
+#include "vector_2.h"
+#include "deserializer.h"
+#include "matrix_3.h"
+#include "serializer.h"
+#include <cassert>
+
+namespace Borges {
+
+Vector_2::Vector_2(std::initializer_list<double> v)
+{
+    assert(v.size() == 2);
+    for (std::size_t i = 0; i < 2; ++i) {
+        v_[i] = v.begin()[i];
+    }
+}
+
+Vector_2::Vector_2(const double v[2])
+{
+    for (std::size_t i = 0; i < 2; ++i) {
+        v_[i] = v[i];
+    }
+}
+
+double
+Vector_2::operator[](std::size_t i) const
+{
+    assert(i < 2);
+    return v_[i];
+}
+
+void
+serialize(Serializer& s, const Vector_2& v)
+{
+    for (std::size_t i = 0; i < 2; ++i) {
+        serialize(s, v[i]);
+    }
+}
+
+void
+deserialize(Deserializer& d, Vector_2* p)
+{
+    double v[2];
+    for (std::size_t i = 0; i < 2; ++i) {
+        v[i] = deserialize<double>(d);
+    }
+    new (p) Vector_2(v);
+}
+
+Vector_2
+operator*(const Matrix_3& m, const Vector_2& v)
+{
+  double mv[2];
+  for (std::size_t i = 0; i < 2; ++i) {
+    mv[i] = 0.0;
+    for (std::size_t j = 0; j < 2; ++j) {
+      mv[i] += m[i][j] * v[j];
+    }
+    mv[i] += m[i][2];
+  }
+  return Vector_2(mv);
+}
+
+} // namespace Borges

--- a/vm/src/vector_2.h
+++ b/vm/src/vector_2.h
@@ -1,0 +1,39 @@
+#ifndef BORGES_VECTOR_2_H
+#define BORGES_VECTOR_2_H
+
+#include "type.h"
+#include <initializer_list>
+
+namespace Borges {
+
+class Serializer;
+class Deserializer;
+class Matrix_3;
+
+class Vector_2 {
+public:
+    explicit Vector_2(std::initializer_list<double> v);
+    explicit Vector_2(const double v[2]);
+    double operator[](std::size_t i) const;
+
+private:
+    double v_[2];
+};
+
+template <>
+struct Type_of<Vector_2>
+    : std::integral_constant<Type, Type::vector_2> {
+};
+
+template <>
+struct Type_of<std::vector<Vector_2>>
+    : std::integral_constant<Type, Type::vector_2_array> {
+};
+
+void serialize(Serializer& serializer, const Vector_2& v);
+void deserialize(Deserializer& deserializer, Vector_2* p);
+Vector_2 operator*(const Matrix_3& m, const Vector_2& v);
+
+} // namespace Borges
+
+#endif // BORGES_VECTOR_2_H

--- a/vm/src/vector_3.cpp
+++ b/vm/src/vector_3.cpp
@@ -1,0 +1,63 @@
+#include "vector_3.h"
+#include "deserializer.h"
+#include "matrix_4.h"
+#include "serializer.h"
+#include <cassert>
+
+namespace Borges {
+
+Vector_3::Vector_3(std::initializer_list<double> v)
+{
+    assert(v.size() == 3);
+    for (std::size_t i = 0; i < 3; ++i) {
+        v_[i] = v.begin()[i];
+    }
+}
+
+Vector_3::Vector_3(const double v[3])
+{
+    for (std::size_t i = 0; i < 3; ++i) {
+        v_[i] = v[i];
+    }
+}
+
+double
+Vector_3::operator[](std::size_t i) const
+{
+    assert(i < 3);
+    return v_[i];
+}
+
+void
+serialize(Serializer& s, const Vector_3& v)
+{
+    for (std::size_t i = 0; i < 3; ++i) {
+        serialize(s, v[i]);
+    }
+}
+
+void
+deserialize(Deserializer& d, Vector_3* p)
+{
+    double v[3];
+    for (std::size_t i = 0; i < 3; ++i) {
+        v[i] = deserialize<double>(d);
+    }
+    new (p) Vector_3(v);
+}
+
+Vector_3
+operator*(const Matrix_4& m, const Vector_3& v)
+{
+  double mv[3];
+  for (std::size_t i = 0; i < 3; ++i) {
+    mv[i] = 0.0;
+    for (std::size_t j = 0; j < 3; ++j) {
+      mv[i] += m[i][j] * v[j];
+    }
+    mv[i] += m[i][3];
+  }
+  return Vector_3(mv);
+}
+
+} // namespace Borges

--- a/vm/src/vector_3.h
+++ b/vm/src/vector_3.h
@@ -1,0 +1,39 @@
+#ifndef BORGES_VECTOR_3_H
+#define BORGES_VECTOR_3_H
+
+#include "type.h"
+#include <initializer_list>
+
+namespace Borges {
+
+class Serializer;
+class Deserializer;
+class Matrix_4;
+
+class Vector_3 {
+public:
+    explicit Vector_3(std::initializer_list<double> v);
+    explicit Vector_3(const double v[3]);
+    double operator[](std::size_t i) const;
+
+private:
+    double v_[3];
+};
+
+template <>
+struct Type_of<Vector_3>
+    : std::integral_constant<Type, Type::vector_3> {
+};
+
+template <>
+struct Type_of<std::vector<Vector_3>>
+    : std::integral_constant<Type, Type::vector_3_array> {
+};
+
+void serialize(Serializer& serializer, const Vector_3& v);
+void deserialize(Deserializer& deserializer, Vector_3* p);
+Vector_3 operator*(const Matrix_4& m, const Vector_3& v);
+
+} // namespace Borges
+
+#endif // BORGES_VECTOR_3_H


### PR DESCRIPTION
This PR should be easier to understand than the previous one.

First, we introduce the enum Type. Type is used to identify types at runtime. This will be necessary for when we introduce the Value type, which can contain a value of a different type at any given time.

Next, we introduce the Type_of template. This template is used to obtain the value of Type corresponding to a given type T. It should be specialized for each type for which we want to obtain run-time type information. This will be necessary for the code generation, where we want to compare the Type of a value on the stack with the Type of the argument expected by a C++ function.

Finally, we introduce some basic types that we want the interpreter to support. This list is far from exhaustive, and we will add more complex types later on, but this set of types is sufficient to exercise all the features we want the interpreter to support.

As a final note, the Const_row class in each Matrix_* class is a so-called proxy class. It's intended use is to allow a matrix to be accessed as if it were a two-dimensional array, but with the added advantage that debug builds will assert if you try to access an element that's not in the matrix.